### PR TITLE
docs: revert numbering of tutorials

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -6,7 +6,6 @@ This page summarizes the available tutorials.
 
 .. toctree::
    :maxdepth: 1
-   :numbered:
    :glob:
 
    *


### PR DESCRIPTION
Following https://github.com/Qiskit/qiskit-addon-obp/pull/1