### PR TITLE
Replace pydocstyle with Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,10 +154,12 @@ max-args = 6
 
 [tool.ruff.lint.extend-per-file-ignores]
 "test/**.py" = [
-    "D",  # pydocstyle
+    "D",    # pydocstyle
 ]
 "docs/**/*" = [
     "E402", # module level import not at top of file
+]
+"docs/conf.py" = [
     "D",    # pydocstyle
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,12 +154,10 @@ max-args = 6
 
 [tool.ruff.lint.extend-per-file-ignores]
 "test/**.py" = [
-    "D",    # pydocstyle
+    "D",  # pydocstyle
 ]
 "docs/**/*" = [
     "E402", # module level import not at top of file
-]
-"docs/conf.py" = [
     "D",    # pydocstyle
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ style = [
 ]
 lint = [
     "qiskit-addon-mpf[style]",
-    "pydocstyle==6.3.0",
     "mypy==1.11.2",
     "pylint==3.3.1",
     "reno>=4.1",
@@ -171,5 +170,8 @@ notice-rgx = """
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals\\.
 """
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.typos.default.extend-words]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ select = [
     "I",   # isort
     "E",   # pycodestyle
     "W",   # pycodestyle
+    "D",   # pydocstyle
     "F",   # pyflakes
     "RUF", # ruff
     "UP",  # pyupgrade
@@ -152,8 +153,12 @@ ignore = [
 max-args = 6
 
 [tool.ruff.lint.extend-per-file-ignores]
+"test/**.py" = [
+    "D",  # pydocstyle
+]
 "docs/**/*" = [
     "E402", # module level import not at top of file
+    "D",    # pydocstyle
 ]
 
 [tool.ruff.lint.flake8-copyright]

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ extras =
 commands =
   ruff format qiskit_addon_mpf/ docs/ test/
   ruff check --fix qiskit_addon_mpf/ docs/ test/
+  ruff check --fix --select D qiskit_addon_mpf/
   nbqa ruff --fix docs/
 
 [testenv:lint]
@@ -27,9 +28,9 @@ extras =
 commands =
   ruff format --check qiskit_addon_mpf/ docs/ test/
   ruff check qiskit_addon_mpf/ docs/ test/
+  ruff check --select D qiskit_addon_mpf/
   ruff check --preview --select CPY001 --exclude "*.ipynb" qiskit_addon_mpf/ test/
   nbqa ruff docs/
-  pydocstyle qiskit_addon_mpf/
   mypy qiskit_addon_mpf/
   pylint -rn qiskit_addon_mpf/ test/
   nbqa pylint -rn docs/

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ extras =
 commands =
   ruff format qiskit_addon_mpf/ docs/ test/
   ruff check --fix qiskit_addon_mpf/ docs/ test/
-  ruff check --fix --select D qiskit_addon_mpf/
   nbqa ruff --fix docs/
 
 [testenv:lint]
@@ -28,7 +27,6 @@ extras =
 commands =
   ruff format --check qiskit_addon_mpf/ docs/ test/
   ruff check qiskit_addon_mpf/ docs/ test/
-  ruff check --select D qiskit_addon_mpf/
   ruff check --preview --select CPY001 --exclude "*.ipynb" qiskit_addon_mpf/ test/
   nbqa ruff docs/
   mypy qiskit_addon_mpf/


### PR DESCRIPTION
Pydocstyle was deprecated in favor of Ruff. Ruff has the exact same lints via the D ruleset.

As before, we only run the doc checks on source code and not tests.