### PR TITLE
ci: align Python version of tox and Github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
I don't know, why this worked before, but you see that https://github.com/Qiskit/qiskit-addon-mpf/actions/runs/12399707124/job/34615220399 failed. This should fix this going forward.