### PR TITLE
Guard against `N_steps != 1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ max-args = 6
 notice-rgx = """
 # This code is a Qiskit project.
 #
-# \\(C\\) Copyright IBM 2024\\.
+# \\(C\\) Copyright IBM \\d{4}((,\\s)\\d{4})*\\.
 #
 # This code is licensed under the Apache License, Version 2\\.0\\. You may
 # obtain a copy of this license in the LICENSE\\.txt file in the root directory

--- a/qiskit_addon_mpf/backends/tenpy_layers/evolver.py
+++ b/qiskit_addon_mpf/backends/tenpy_layers/evolver.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -66,13 +66,21 @@ class LayerwiseEvolver(tenpy_tebd.TEBDEvolver):
         """Perform a single time step of TEBD.
 
         Args:
-            N_steps: should always be ``1`` in this case. See
-                :external:class:`~tenpy.algorithms.tebd.TEBDEngine` for more details.
+            N_steps: should always be ``1`` for this time-evolver, otherwise an error will be raised
+                (see below).
             dt: the time-step to use.
 
         Returns:
             The truncation error.
+
+        Raises:
+            RuntimeError: if ``N_steps`` is not equal to ``1``.
         """
+        if N_steps != 1:
+            raise RuntimeError(
+                "The LayerwiseEvolver only supports a single evolution step at a time!"
+            )
+
         if dt is not None:  # pragma: no branch
             assert dt == self._U_param["delta_t"]
 

--- a/releasenotes/notes/tenpy-layers-N-steps-guard-96e57723af75c8a0.yaml
+++ b/releasenotes/notes/tenpy-layers-N-steps-guard-96e57723af75c8a0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Guards against unexpected behavior when ``N_steps != 1`` in
+    :meth:`qiskit_addon_mpf.backends.tenpy_layers.LayerwiseEvolver.evolve`.

--- a/test/backends/tenpy_layers/test_evolver.py
+++ b/test/backends/tenpy_layers/test_evolver.py
@@ -1,0 +1,39 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024, 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+import pytest
+from qiskit.circuit import QuantumCircuit
+from qiskit_addon_mpf.backends import HAS_TENPY
+
+if HAS_TENPY:
+    from qiskit_addon_mpf.backends.tenpy_layers import LayerModel, LayerwiseEvolver
+    from qiskit_addon_mpf.backends.tenpy_tebd import MPOState
+
+
+@pytest.mark.skipif(not HAS_TENPY, reason="Tenpy is required for these unittests")
+class TestLayerwiseEvolver:
+    def test_N_steps_guard(self):
+        L = 6
+
+        qc = QuantumCircuit(L)
+        for i in range(0, L - 1, 2):
+            qc.rzz(1.0, i, i + 1)
+
+        model = LayerModel.from_quantum_circuit(qc)
+
+        common_state = MPOState.initialize_from_lattice(model.lat)
+
+        algo = LayerwiseEvolver(common_state, [model], {})
+
+        with pytest.raises(RuntimeError):
+            algo.evolve(2, 0.1)


### PR DESCRIPTION
The `LayerwiseEvolver` based on `tenpy` has a `N_steps` argument in its public `evolve` method.
However, also as documented, this is supposed to be 1.

When it is not set to 1, the code runs fine but produces unexpected results.
This PR adds a guard against this to ensure the user cannot run into this.