### PR TITLE
feat: permit the disabling of Sz conservation

### DIFF
--- a/qiskit_addon_mpf/backends/tenpy_layers/model.py
+++ b/qiskit_addon_mpf/backends/tenpy_layers/model.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -37,9 +37,6 @@ class LayerModel(CouplingMPOModel, NearestNeighborModel):
 
         See :external:meth:`~tenpy.models.model.CouplingMPOModel.init_sites` for more details.
 
-        .. caution::
-           Currently, this enforces ``Sz`` conservation on all sites.
-
         Args:
             model_params: the model parameters.
 
@@ -48,8 +45,6 @@ class LayerModel(CouplingMPOModel, NearestNeighborModel):
         """
         # WARN: we use our own default to NOT sort charges (contrary to TeNPy default: `True`)
         sort_charge = model_params.get("sort_charge", False, bool)
-        # TODO: currently, this default Sz conservation is coupled to the LegCharge definition in
-        # MPOState.initialize_from_lattice. Not conserving Sz errors with 'Different ChargeInfo'.
         conserve = model_params.get("conserve", "Sz", str)
         return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)
 

--- a/releasenotes/notes/tenpy-conserve-none-f34f73b38b89111c.yaml
+++ b/releasenotes/notes/tenpy-conserve-none-f34f73b38b89111c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    TeNPy can disable ``Sz`` conservation. Previously, the
+    :meth:`~qiskit_addon_mpf.backends.tenpy_tebd.MPOState.initialize_from_lattice`
+    method did not support this, but a new keyword argument ``conserve`` has
+    been added which allows the disabling of ``Sz`` conservation. The default
+    remains to be ``True``.

--- a/test/backends/tenpy_layers/test_e2e.py
+++ b/test/backends/tenpy_layers/test_e2e.py
@@ -1,6 +1,6 @@
 # This code is a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -24,6 +24,7 @@ if HAS_TENPY:
     from qiskit_addon_mpf.backends.tenpy_layers import LayerModel, LayerwiseEvolver
     from qiskit_addon_mpf.backends.tenpy_tebd import MPOState, MPS_neel_state, TEBDEvolver
     from tenpy.models import XXZChain2
+    from tenpy.networks.site import SpinHalfSite
 
 
 def gen_ext_field_layer(n, hz):
@@ -52,32 +53,51 @@ def gen_even_coupling_layer(n, Jxx, Jz, J):
     return qc
 
 
+class ConserveXXZChain2(XXZChain2):
+    """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
+
+    def init_sites(self, model_params):
+        conserve = model_params.get("conserve", "Sz", bool)
+        sort_charge = model_params.get("sort_charge", True, bool)
+        return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
+
+
 @pytest.mark.skipif(not HAS_TENPY, reason="TeNPy is required for these unittests")
 class TestEndToEnd:
     @pytest.mark.parametrize(
-        ["time", "expected_A", "expected_b", "expected_coeffs"],
+        ["time", "expected_A", "expected_b", "expected_coeffs", "conserve"],
         [
             (
                 0.5,
                 [[1.0, 0.9997562], [0.9997562, 1.0]],
                 [0.99944125, 0.99857914],
                 [2.2680558, -1.26805551],
+                "None",
+            ),
+            (
+                0.5,
+                [[1.0, 0.9997562], [0.9997562, 1.0]],
+                [0.99944125, 0.99857914],
+                [2.2680558, -1.26805551],
+                "Sz",
             ),
             (
                 1.0,
                 [[1.0, 0.99189288], [0.99189288, 1.0]],
                 [0.98478594, 0.9676077],
                 [1.55870387, -0.55870387],
+                "Sz",
             ),
             (
                 1.5,
                 [[1.0, 0.95352741], [0.95352741, 1.0]],
                 [0.9032996, 0.71967399],
                 [2.47563369, -1.47563369],
+                "Sz",
             ),
         ],
     )
-    def test_end_to_end(self, time, expected_A, expected_b, expected_coeffs):
+    def test_end_to_end(self, time, expected_A, expected_b, expected_coeffs, conserve):
         np.random.seed(0)
 
         # constants
@@ -97,13 +117,14 @@ class TestEndToEnd:
 
         # This is the full model that we want to simulate. It is used for the "exact" time evolution
         # (which is approximated via a fourth-order Suzuki-Trotter formula).
-        exact_model = XXZChain2(
+        exact_model = ConserveXXZChain2(
             {
                 "L": L,
                 "Jz": 4.0 * Jz * J,
                 "Jxx": 4.0 * Jxx * J,
                 "hz": 2.0 * hz,
                 "bc_MPS": "finite",
+                "conserve": conserve,
                 "sort_charge": False,
             }
         )
@@ -112,22 +133,26 @@ class TestEndToEnd:
         # Trotter circuit and sliced it using `qiskit_addon_utils.slicing`.
         odd_coupling_layer = LayerModel.from_quantum_circuit(
             gen_odd_coupling_layer(L, Jxx, Jz, J),
+            conserve=conserve,
             bc_MPS="finite",
         )
         even_coupling_layer = LayerModel.from_quantum_circuit(
             gen_even_coupling_layer(L, Jxx, Jz, 2.0 * J),  # factor 2 because its the central layer
+            conserve=conserve,
             bc_MPS="finite",
         )
         odd_onsite_layer = LayerModel.from_quantum_circuit(
             gen_ext_field_layer(L, hz),
             keep_only_odd=True,
             scaling_factor=0.5,
+            conserve=conserve,
             bc_MPS="finite",
         )
         even_onsite_layer = LayerModel.from_quantum_circuit(
             gen_ext_field_layer(L, hz),
             keep_only_odd=False,
             scaling_factor=0.5,
+            conserve=conserve,
             bc_MPS="finite",
         )
         # Our layers combine to form a second-order Suzuki-Trotter formula as follows:
@@ -159,7 +184,7 @@ class TestEndToEnd:
         model = setup_dynamic_lse(
             [4, 3],
             time,
-            partial(MPOState.initialize_from_lattice, exact_model.lat),
+            partial(MPOState.initialize_from_lattice, exact_model.lat, conserve=conserve == "Sz"),
             partial(
                 TEBDEvolver,
                 model=exact_model,


### PR DESCRIPTION
This PR allows an end-user to _disable_ the `Sz` conservation in a TeNPy-based dynamic MPF calculation.

Previously, we did not support this as stated in #36.
TeNPy's `XXZChain2` class actually hard-codes the `Sz` conservation, contrary to my statement in #36.
The user can do so manually with a custom subclass until TeNPy supports this natively.

With this PR, the user has full flexibility over enabling/disabling `Sz` conservation.

Closes #36.