### PR TITLE
[dev] allow MPS states for testing purposes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 quimb = [
-    "quimb>=1.8.3, <2",
+    "quimb>=1.10.0, <2",
     "qiskit-quimb",
 ]
 tenpy = [


### PR DESCRIPTION
This commit adds support for MPS states within the custom time evolver implementations. This is useful for testing purposes when comparing the algorithms against the backend specific default implementations (which only allow MPS) or (e.g.) exact statevector simulations of `QuantumCircuit` objects.

This feature is not meant for end-user consumption and, thus, not advertised as such.