### PR TITLE
Support Qiskit 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.23",
     "cvxpy>=1.6",
-    "qiskit>=1.2, <2",
+    "qiskit>=1.2, <3",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/qiskit-2.0-68f026f7c2517f92.yaml
+++ b/releasenotes/notes/qiskit-2.0-68f026f7c2517f92.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    This package is now compatible with Qiskit SDK 2.0.


### PR DESCRIPTION
Much like [`qiskit-addon-utils`](https://github.com/Qiskit/qiskit-addon-utils/pull/76) and [`qiskit-addon-obp`](https://github.com/Qiskit/qiskit-addon-obp/pull/66) we only need to adjust the Qiskit version upper bound in order to support Qiskit 2.0.

I am not backporting this because a new release is overdue anyways.