### PR TITLE
Update intersphinx mapping URLs & others

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### About
 
-[Qiskit addons](https://docs.quantum.ibm.com/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+[Qiskit addons](https://quantum.cloud.ibm.com/docs/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains the Qiskit addon for multi-product formulas (MPFs).
 These can be used to reduce the Trotter error of Hamiltonian dynamics.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "cvxpy": ("https://www.cvxpy.org/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
     "qiskit_addon_utils": ("https://qiskit.github.io/qiskit-addon-utils/", None),
     "quimb": ("https://quimb.readthedocs.io/en/latest/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit addon: multi-product formulas (MPF)
 ##########################################
 
-`Qiskit addons <https://docs.quantum.ibm.com/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+`Qiskit addons <https://quantum.cloud.ibm.com/docs/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains the Qiskit addon for multi-product formulas (MPFs).
 These can be used to reduce the Trotter error of Hamiltonian dynamics.

--- a/docs/tutorials/01_getting_started.ipynb
+++ b/docs/tutorials/01_getting_started.ipynb
@@ -21,9 +21,9 @@
     "    - Initialize our problem's Hamiltonian\n",
     "    - <font color=\"#0F62FE\">Use an MPF to generate the Trotterized time-evolution circuits</font>\n",
     "- **Step 2: Optimize the problem**\n",
-    "    - Here we transpile our circuits for a [GenericBackendV2](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2)\n",
+    "    - Here we transpile our circuits for a [GenericBackendV2](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2)\n",
     "- **Step 3: Execute experiments**\n",
-    "    - Use a [StatevectorEstimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.StatevectorEstimator) for sake of simplicity in this notebook\n",
+    "    - Use a [StatevectorEstimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.StatevectorEstimator) for sake of simplicity in this notebook\n",
     "- **Step 4: Reconstruct results**\n",
     "    - <font color=\"#0F62FE\">Compute the MPF expectation value</font>"
    ]
@@ -68,7 +68,7 @@
     "The [qiskit_addon_utils](https://qiskit.github.io/qiskit-addon-utils/) package provides some reusable functionalities for various purposes.\n",
     "\n",
     "Its [qiskit_addon_utils.problem_generators](https://qiskit.github.io/qiskit-addon-utils/stubs/qiskit_addon_utils.problem_generators.html) module provides functions to generate Heisenberg-like Hamiltonians on a given connectivity graph.\n",
-    "This graph can be either a [rustworkx.PyGraph](https://www.rustworkx.org/apiref/rustworkx.PyGraph.html) or a [CouplingMap](https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.CouplingMap) making it easy to use in Qiskit-centric workflows.\n",
+    "This graph can be either a [rustworkx.PyGraph](https://www.rustworkx.org/apiref/rustworkx.PyGraph.html) or a [CouplingMap](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.transpiler.CouplingMap) making it easy to use in Qiskit-centric workflows.\n",
     "\n",
     "In the following, we create a simple line of 10 qubits using the `CouplingMap.from_line` method."
    ]
@@ -136,7 +136,7 @@
     "tags": []
    },
    "source": [
-    "Next, we generate the [SparsePauliOp](https://docs.quantum.ibm.com/api/qiskit/qiskit.quantum_info.SparsePauliOp) on the provided connectivity with the desired constants."
+    "Next, we generate the [SparsePauliOp](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.quantum_info.SparsePauliOp) on the provided connectivity with the desired constants."
    ]
   },
   {
@@ -717,7 +717,7 @@
     "## Step 2: Optimize the problem\n",
     "\n",
     "Normally, this is the step in the pattern during which you optimize your circuits for execution on hardware.\n",
-    "Here, since we only use a noiseless simulator, we simply transpile our circuit for a [GenericBackendV2](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2)."
+    "Here, since we only use a noiseless simulator, we simply transpile our circuit for a [GenericBackendV2](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.providers.fake_provider.GenericBackendV2)."
    ]
   },
   {
@@ -756,7 +756,7 @@
    "source": [
     "## Step 3: Execute quantum experiments\n",
     "\n",
-    "As explained in the very beginning, we will skip the optimization step 2 because we are simply going to compute our target observable's expectation values using a noise-free simulator, namely the [StatevectorEstimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.StatevectorEstimator)."
+    "As explained in the very beginning, we will skip the optimization step 2 because we are simply going to compute our target observable's expectation values using a noise-free simulator, namely the [StatevectorEstimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.StatevectorEstimator)."
    ]
   },
   {


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.