### PR TITLE
Only define `ConserveXXZChain2` class if TeNPy is installed

### DIFF
--- a/test/backends/tenpy_layers/test_e2e.py
+++ b/test/backends/tenpy_layers/test_e2e.py
@@ -54,6 +54,7 @@ def gen_even_coupling_layer(n, Jxx, Jz, J):
 
 
 if HAS_TENPY:
+
     class ConserveXXZChain2(XXZChain2):
         """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
 

--- a/test/backends/tenpy_layers/test_e2e.py
+++ b/test/backends/tenpy_layers/test_e2e.py
@@ -53,13 +53,14 @@ def gen_even_coupling_layer(n, Jxx, Jz, J):
     return qc
 
 
-class ConserveXXZChain2(XXZChain2):
-    """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
+if HAS_TENPY:
+    class ConserveXXZChain2(XXZChain2):
+        """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
 
-    def init_sites(self, model_params):
-        conserve = model_params.get("conserve", "Sz", bool)
-        sort_charge = model_params.get("sort_charge", True, bool)
-        return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
+        def init_sites(self, model_params):
+            conserve = model_params.get("conserve", "Sz", bool)
+            sort_charge = model_params.get("sort_charge", True, bool)
+            return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
 
 
 @pytest.mark.skipif(not HAS_TENPY, reason="TeNPy is required for these unittests")

--- a/test/backends/tenpy_tebd/test_e2e.py
+++ b/test/backends/tenpy_tebd/test_e2e.py
@@ -25,6 +25,7 @@ if HAS_TENPY:
 
 
 if HAS_TENPY:
+
     class ConserveXXZChain2(XXZChain2):
         """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
 

--- a/test/backends/tenpy_tebd/test_e2e.py
+++ b/test/backends/tenpy_tebd/test_e2e.py
@@ -24,13 +24,14 @@ if HAS_TENPY:
     from tenpy.networks.site import SpinHalfSite
 
 
-class ConserveXXZChain2(XXZChain2):
-    """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
+if HAS_TENPY:
+    class ConserveXXZChain2(XXZChain2):
+        """TeNPy's XXZChain2 hard-codes Sz conservation. This subclass makes it configurable."""
 
-    def init_sites(self, model_params):
-        conserve = model_params.get("conserve", "Sz", bool)
-        sort_charge = model_params.get("sort_charge", True, bool)
-        return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
+        def init_sites(self, model_params):
+            conserve = model_params.get("conserve", "Sz", bool)
+            sort_charge = model_params.get("sort_charge", True, bool)
+            return SpinHalfSite(conserve=conserve, sort_charge=sort_charge)  # use predefined Site
 
 
 @pytest.mark.skipif(not HAS_TENPY, reason="TeNPy is required for these unittests")


### PR DESCRIPTION
Trying to run the unit tests without the optional dependency TeNPy currently fails because a class is defined using `XXZChain2` from `tenpy.models`.

This PR simply prevents that class from being defined if TeNPy is not installed.