### PR TITLE
fix: minimum cvxpy version for doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.9"
 
 dependencies = [
     "numpy>=1.23",
-    "cvxpy>=1.6",
+    "cvxpy>=1.7.3",
     "qiskit>=1.2, <3",
 ]
 


### PR DESCRIPTION
590d64038b16e856c3239897f6f5012a0067b0da updated the expected doctest result to match the latest cvxpy version.
However, it did not update the minimum version.

~This PR addresses that but explicitly only for the doctest tests to avoid unnecessary version requirements for otherwise working functionality.~
That does not work with how the extremal package versions get set. Thus we simply bump the required minimum version to match.