### PR TITLE
Assorted CI fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (minimum versions)
         shell: bash
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip
           python -m pip install extremal-python-dependencies~=0.0.5
           pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
           extremal-python-dependencies pin-dependencies-to-minimum --inplace

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies (minimum versions)
         shell: bash
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           python -m pip install extremal-python-dependencies~=0.0.5
           pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
           extremal-python-dependencies pin-dependencies-to-minimum --inplace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,4 +192,5 @@ notice-rgx = """
 convention = "google"
 
 [tool.typos.default.extend-words]
+CPY = "CPY"
 expec = "expec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 ]
 doctest = [
     "qiskit-addon-mpf[basetest,notebook-dependencies]",
-    "pytest-doctestplus>=1.2.1",
+    "pytest-doctestplus>=1.3.0",
 ]
 nbtest = [
     "qiskit-addon-mpf[basetest]",

--- a/qiskit_addon_mpf/backends/quimb_tebd/state.py
+++ b/qiskit_addon_mpf/backends/quimb_tebd/state.py
@@ -90,9 +90,9 @@ class MPOState(MatrixProductOperator, State):
             inplace: whether to perform the gate application in-place or return a new
                 :class:`MPOState` with the gate applied to it.
             conj: whether the gate should be applied to the lower (``conj=False``, the default,
-                :external:meth:`~quimb.tensor.tensor_arbgeom.TensorNetworkGenOperator.lower_ind`)
+                :external:meth:`~quimb.tensor.TensorNetworkGenOperator.lower_ind`)
                 or upper (``conj=True``,
-                :external:meth:`~quimb.tensor.tensor_arbgeom.TensorNetworkGenOperator.upper_ind`)
+                :external:meth:`~quimb.tensor.TensorNetworkGenOperator.upper_ind`)
                 indices of the underlying MPO.
 
                 .. note::

--- a/qiskit_addon_mpf/costs/sum_of_squares.py
+++ b/qiskit_addon_mpf/costs/sum_of_squares.py
@@ -41,26 +41,22 @@ def setup_sum_of_squares_problem(
 
     Here is an example:
 
-    .. doctest-requires:: cvxpy>=1.8.0
-
-        >>> from qiskit_addon_mpf.costs import setup_sum_of_squares_problem
-        >>> from qiskit_addon_mpf.static import setup_static_lse
-        >>> lse = setup_static_lse([1,2,3], order=2, symmetric=True)
-        >>> problem, coeffs = setup_sum_of_squares_problem(lse, max_l1_norm=3.0)
-        >>> print(problem)  # doctest: +FLOAT_CMP, +NORMALIZE_WHITESPACE
-        minimize quad_over_lin(Vstack([1. 1.     1.]         @ x + -1.0,
-                                      [1. 0.25   0.11111111] @ x + -0.0,
-                                      [1. 0.0625 0.01234568] @ x + -0.0), 1.0, None, False)
-        subject to Sum(x, None, False) == 1.0
-                   norm1(x) <= 3.0
+    >>> from qiskit_addon_mpf.costs import setup_sum_of_squares_problem
+    >>> from qiskit_addon_mpf.static import setup_static_lse
+    >>> lse = setup_static_lse([1,2,3], order=2, symmetric=True)
+    >>> problem, coeffs = setup_sum_of_squares_problem(lse, max_l1_norm=3.0)
+    >>> print(problem)  # doctest: +FLOAT_CMP, +NORMALIZE_WHITESPACE, +SKIP
+    minimize quad_over_lin(Vstack([1. 1.     1.]         @ x + -1.0,
+                                  [1. 0.25   0.11111111] @ x + -0.0,
+                                  [1. 0.0625 0.01234568] @ x + -0.0), 1.0, None, False)
+    subject to Sum(x, None, False) == 1.0
+               norm1(x) <= 3.0
 
     You can then solve the problem and access the expansion coefficients like so:
 
-    .. doctest-requires:: cvxpy>=1.8.0
-
-        >>> final_cost = problem.solve()
-        >>> print(coeffs.value)  # doctest: +FLOAT_CMP
-        [ 0.03513467 -1.          1.96486533]
+    >>> final_cost = problem.solve()
+    >>> print(coeffs.value)  # doctest: +FLOAT_CMP
+    [ 0.03513467 -1.          1.96486533]
 
     Args:
         lse: the linear system of equations from which to build the model.

--- a/qiskit_addon_mpf/costs/sum_of_squares.py
+++ b/qiskit_addon_mpf/costs/sum_of_squares.py
@@ -41,22 +41,26 @@ def setup_sum_of_squares_problem(
 
     Here is an example:
 
-    >>> from qiskit_addon_mpf.costs import setup_sum_of_squares_problem
-    >>> from qiskit_addon_mpf.static import setup_static_lse
-    >>> lse = setup_static_lse([1,2,3], order=2, symmetric=True)
-    >>> problem, coeffs = setup_sum_of_squares_problem(lse, max_l1_norm=3.0)
-    >>> print(problem)  # doctest: +FLOAT_CMP
-    minimize quad_over_lin(Vstack([1. 1.     1.]         @ x + -1.0,
-                                  [1. 0.25   0.11111111] @ x + -0.0,
-                                  [1. 0.0625 0.01234568] @ x + -0.0), 1.0)
-    subject to Sum(x, None, False) == 1.0
-               norm1(x) <= 3.0
+    .. doctest-requires:: cvxpy>=1.8.0
+
+        >>> from qiskit_addon_mpf.costs import setup_sum_of_squares_problem
+        >>> from qiskit_addon_mpf.static import setup_static_lse
+        >>> lse = setup_static_lse([1,2,3], order=2, symmetric=True)
+        >>> problem, coeffs = setup_sum_of_squares_problem(lse, max_l1_norm=3.0)
+        >>> print(problem)  # doctest: +FLOAT_CMP, +NORMALIZE_WHITESPACE
+        minimize quad_over_lin(Vstack([1. 1.     1.]         @ x + -1.0,
+                                      [1. 0.25   0.11111111] @ x + -0.0,
+                                      [1. 0.0625 0.01234568] @ x + -0.0), 1.0, None, False)
+        subject to Sum(x, None, False) == 1.0
+                   norm1(x) <= 3.0
 
     You can then solve the problem and access the expansion coefficients like so:
 
-    >>> final_cost = problem.solve()
-    >>> print(coeffs.value)  # doctest: +FLOAT_CMP
-    [ 0.03513467 -1.          1.96486533]
+    .. doctest-requires:: cvxpy>=1.8.0
+
+        >>> final_cost = problem.solve()
+        >>> print(coeffs.value)  # doctest: +FLOAT_CMP
+        [ 0.03513467 -1.          1.96486533]
 
     Args:
         lse: the linear system of equations from which to build the model.

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
   pytest --doctest-plus --doctest-plus-atol 0.0001 --doctest-only {posargs}
 
 [testenv:coverage]
-basepython = python3.10
+basepython = python3.11
 deps =
   coverage>=7.4.1
 extras =


### PR DESCRIPTION
The doctest output was broken when cvxpy>=1.8.0 was used. We cannot lift our minimum required version to this, because it no longer supports Python 3.10 which we do support. Since this is only a printing artifact though, it is fine to lift our python version when testing coverage.