### PR TITLE
Limit maximum supported cvxpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "numpy>=2.0",
-    "cvxpy>=1.7.5",
+    "cvxpy>=1.7.5, <1.9",
     "qiskit>=1.2, <3",
 ]
 


### PR DESCRIPTION
For now, this is a "quick fix" to get CI to pass again. We should check the actual underlying problem and address that though.